### PR TITLE
Fix webmention.rocks test cases

### DIFF
--- a/shared/lib/get-wm-endpoints.js
+++ b/shared/lib/get-wm-endpoints.js
@@ -46,9 +46,13 @@ async function main(urls, progress = () => {}, limit = 10) {
   )
     .then((res) => {
       return urls.map((url) => {
+        // Use exact match instead of startsWith to avoid matching
+        // https://webmention.rocks/test/1 to https://webmention.rocks
+        // Also, normalize URLs by removing trailing slashes for comparison
+        const normalizeUrl = (u) => u.endsWith('/') ? u.slice(0, -1) : u;
         return Object.assign(
           { url },
-          res.find(({ source }) => url.startsWith(source))
+          res.find(({ source }) => normalizeUrl(url) === normalizeUrl(source))
         );
       });
     })

--- a/shared/lib/links.js
+++ b/shared/lib/links.js
@@ -13,10 +13,17 @@ function links({ $, base, url = '' }) {
     .map((i, element) => {
       const $$ = $(element);
 
-      let permalink = resolve(
-        baseHref,
-        $$.find('.u-url').attr('href') || element.link || ''
-      );
+      // Prefer element.link (from microformat properties.url) if it's an absolute URL,
+      // otherwise try .u-url from content, then fall back to element.link or empty
+      let permalink;
+      if (element.link && element.link.startsWith('http')) {
+        permalink = element.link;
+      } else {
+        permalink = resolve(
+          baseHref,
+          $$.find('.u-url').attr('href') || element.link || ''
+        );
+      }
 
       if (!permalink.includes(hostname) && base.length === 1) {
         // it's probably bad, so let's reset it


### PR DESCRIPTION
This PR fixes two issues. One is about URL comparisons for webmention targets. As it is the case for the webmention.rocks test cases. Each case has a webmention target url but the comparision was checking if the webmention.rocks main page has a target, which was not the case.

The second issue is about permalink extraction. The tool was unable to extract the correct source url when sending a webmention.

**URL normalization and comparison improvements:**

* In `get-wm-endpoints.js`, updated the matching logic to use exact URL equality instead of `startsWith`, and added URL normalization by removing trailing slashes for more reliable comparisons.

**Permalink extraction enhancements:**

* In `links.js`, modified the permalink extraction to prefer `element.link` if it is an absolute URL, otherwise fallback to `.u-url` or the original link, ensuring more accurate link resolution from microformats.