### PR TITLE
Fix: limit param

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@benjifs/wm",
-  "version": "1.6.0",
+  "version": "1.6.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@benjifs/wm",
-      "version": "1.6.0",
+      "version": "1.6.1",
       "license": "MIT",
       "dependencies": {
         "cheerio": "^0.22.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@benjifs/wm",
-  "version": "1.6.0",
+  "version": "1.6.1",
   "description": "Fork of @remy/webmention",
   "main": "./shared/lib/webmention.js",
   "repository": "github:benjifs/wm",

--- a/shared/lib/webmention.js
+++ b/shared/lib/webmention.js
@@ -20,6 +20,7 @@ class Webmention extends EventEmitter {
     this.mentions = [];
     this.endpoints = null;
     this.counts = {};
+    this.isRSS = false;
 
     this.on('progress-update', ({ type, value, data }) => {
       const v = (this.counts[type] = (this.counts[type] || 0) + value);
@@ -79,7 +80,9 @@ class Webmention extends EventEmitter {
         const endpoints = await getEndpoints(
           links.filter(ignoreOwn(permalink)),
           (type, data) => this.emit(type, data),
-          // this.limit
+          // if limit is used and it's an RSS feed, assume the limit is
+          // for items in the feed. Otherwise, use limit for entry
+          this.isRSS ? null : this.limit
         );
 
         if (endpoints.length === 0) return false;
@@ -104,6 +107,7 @@ class Webmention extends EventEmitter {
   getFromContent(content) {
     if (smellsLikeRSS(content)) {
       this.emit('log', 'Content is RSS');
+      this.isRSS = true;
       return this.getLinksFromFeed({ xml: content });
     }
 


### PR DESCRIPTION
The current behaviour made it so that `--limit` was only used when parsing an RSS feed. This was a setup as a quickfix to deal with remy/wm/issues/66 in this fork.

This change makes it so that:
- If you use `--limit 1` with an RSS feed, it will only check the latest item of the RSS feed but check for up to 10 (default limit) mentions in that entry.
- If you use `--limit 1` with an entry then it will limit the amount of mentions sent from that entry to that number.

 These could be setup as two separate limit params but for now, this is whats supported.